### PR TITLE
Prevented recursive zsh starting.

### DIFF
--- a/shell/setup_session.sh
+++ b/shell/setup_session.sh
@@ -42,8 +42,6 @@ use_pure_theme() {
 
 # Main function. Run on source loaded.
 run() {
-  zsh
-
   start_tmux
   source_subscripts
   source_local_zshrc


### PR DESCRIPTION
When ZSH was started it would source setup_session.sh which contained a call to zsh, causing a stack overflow from infinitely starting zsh within zsh.